### PR TITLE
Bug in mask definition

### DIFF
--- a/layers.py
+++ b/layers.py
@@ -30,7 +30,7 @@ class MaskedConv2d(nn.Conv2d):
             mask[:, :, height // 2 + 1:] = 0
         else:
             mask[:, :, height // 2, width // 2 + 1:] = 0
-            mask[:, :, height // 2] = 0
+            mask[:, :, height // 2 + 1:] = 0
         self.register_buffer('mask', mask)
 
     def forward(self, x):


### PR DESCRIPTION
In __init__ of MaskedConv2d, definition of "mask" for mask_type= 'B' seems to be wrong. Correction suggested here.